### PR TITLE
Add Observer.pass_list() method to directly return a list of overpass…

### DIFF
--- a/examples/all_visual_satellites.py
+++ b/examples/all_visual_satellites.py
@@ -18,7 +18,7 @@ def all_visual_satellites():
     for tle in tles:
         satellite = SGP4Predictor.from_tle(tle)
         observer = Observer(location, satellite, aos_at_dg=10)
-        passes = list(observer.iter_passes(start, end, visible_only=True))
+        passes = observer.pass_list(start, end, visible_only=True)
         overpasses += passes
     source.save()
     return overpasses

--- a/examples/brute_force_observer.py
+++ b/examples/brute_force_observer.py
@@ -26,8 +26,7 @@ def brute_force_observer():
     source.add_tle(tle)
     satellite = SatellitePredictor(25544, source)
     observer = BruteForceObserver(location, satellite, aos_at_dg=min_elevation, time_step=5, tolerance_s=0.1)
-    pass_iterator =  observer.iter_passes(date_start, limit_date=date_end)
-    overpasses = list(pass_iterator)
+    overpasses =  observer.pass_list(date_start, limit_date=date_end)
     manager = PasspredictManager(
         location,
         tle,

--- a/examples/celestrak_source.py
+++ b/examples/celestrak_source.py
@@ -12,8 +12,7 @@ def celestrak_source():
     tle = source.get_tle(25544)  # International space station, Norad ID 25544
     satellite = SGP4Predictor.from_tle(tle)
     observer = Observer(location, satellite)
-    pass_iterator =  observer.iter_passes(date_start, limit_date=date_end)
-    overpasses = list(pass_iterator)
+    overpasses =  observer.pass_list(date_start, limit_date=date_end)
     print(overpasses)
 
 

--- a/examples/standard_observer.py
+++ b/examples/standard_observer.py
@@ -25,8 +25,7 @@ def standard_observer():
     )
     satellite = SGP4Predictor.from_tle(tle)
     observer = Observer(location, satellite, aos_at_dg=min_elevation, tolerance_s=0.5)
-    pass_iterator = observer.iter_passes(date_start, limit_date=date_end)
-    overpasses = list(pass_iterator)
+    overpasses = observer.pass_list(date_start, limit_date=date_end)
     manager = PasspredictManager(
         location,
         tle,

--- a/src/passpredict/observers/standard.py
+++ b/src/passpredict/observers/standard.py
@@ -87,7 +87,7 @@ class Observer(ObserverBase):
         """Returns a classic predicted pass"""
         data = defaultdict()
         data.update({
-            'satid': self.predictor.satid,
+            'satid': self.satellite.satid,
             'location': self.location,
             'type': basic_pass.type,
             'aos': self.point(basic_pass.aos_dt),
@@ -116,7 +116,7 @@ class Observer(ObserverBase):
                 return candidate
         else:
             # logger.error('Could not find a descending pass over %s start date: %s - TLE: %s',
-            #              self.location, ascending_date, self.predictor.tle)
+            #              self.location, ascending_date, self.satellite.tle)
             raise PropagationError("Can not find an descending phase")
 
     def _find_nearest_ascending(self, descending_date):
@@ -125,7 +125,7 @@ class Observer(ObserverBase):
                 return candidate
         else:
             # logger.error('Could not find an ascending pass over %s start date: %s - TLE: %s',
-            #              self.location, descending_date, self.predictor.tle)
+            #              self.location, descending_date, self.satellite.tle)
             raise PropagationError('Can not find an ascending phase')
 
     def _sample_points(self, date):
@@ -230,7 +230,7 @@ class Observer(ObserverBase):
     def _orbit_step(self, size):
         """Returns a time step, that will make the satellite advance a given number of orbits"""
         step_in_radians = size * 2 * pi
-        seconds = (step_in_radians / self.predictor.mean_motion) * 60
+        seconds = (step_in_radians / self.satellite.mean_motion) * 60
         return datetime.timedelta(seconds=seconds)
 
     def _find_aos(self, tca):

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -24,10 +24,10 @@ def assert_overpass_accuracy_with_brute_force_observer(location, tle, start, end
     date = start
     if len(expected_overpasses) == 0:
         with pytest.raises(NotReachable):
-            pass_ = observer.get_next_pass(date, limit_date=end)
+            pass_ = observer.next_pass(date, limit_date=end)
         return
     for expected_pass in expected_overpasses:
-        pass_ = observer.get_next_pass(date, limit_date=end)
+        pass_ = observer.next_pass(date, limit_date=end)
         assert_datetime_approx(pass_.aos.dt, expected_pass.aos.dt, dt_tol)
         assert_datetime_approx(pass_.los.dt, expected_pass.los.dt, dt_tol)
         assert_datetime_approx(pass_.tca.dt, expected_pass.tca.dt, dt_tol)
@@ -89,7 +89,7 @@ def test_bugsat_predictions(observer_class, observer_kwargs):
             date = datetime.strptime(
                 "2014-10-22 20:18:11.921921", '%Y-%m-%d %H:%M:%S.%f').replace(tzinfo=UTC)
 
-        pass_ = observer.get_next_pass(date)
+        pass_ = observer.next_pass(date)
         assert_datetime_approx(pass_.aos.dt, aos, 1)
         assert_datetime_approx(pass_.los.dt, los, 1)
         assert_datetime_approx(pass_.tca.dt, max_elevation_date, 1)

--- a/tests/test_observers_against_heavens_above.py
+++ b/tests/test_observers_against_heavens_above.py
@@ -83,7 +83,7 @@ def test_heavens_above_zurich_iss_visibility_predictions():
         vis_end = datetime.strptime(f"{date_str} {line_parts[8]}+0100", "%Y %d %b %H:%M:%S%z")
 
         # Find next pass
-        pass_ = observer.get_next_pass(date, limit_date=end, visible_only=True)
+        pass_ = observer.next_pass(date, limit_date=end, visible_only=True)
         assert_datetime_approx(pass_.vis_begin.dt, vis_begin, 1.5)
         assert_datetime_approx(pass_.vis_end.dt, vis_end, 1.5)
         assert_datetime_approx(pass_.vis_tca.dt, tca, 1.5)
@@ -163,7 +163,7 @@ class TestHeavensAboveSanAntonioHSTVisibilty:
             vis_end = datetime.strptime(f"{date_str} {line_parts[8]}-0600", "%Y %d %b %H:%M:%S%z")
 
             # Find next pass
-            pass_ = self.observer.get_next_pass(date, limit_date=end, visible_only=True)
+            pass_ = self.observer.next_pass(date, limit_date=end, visible_only=True)
             assert_datetime_approx(pass_.vis_begin.dt, vis_begin, 1.5)
             assert_datetime_approx(pass_.vis_end.dt, vis_end, 1.5)
             assert_datetime_approx(pass_.vis_tca.dt, tca, 1.5)
@@ -221,7 +221,7 @@ class TestHeavensAboveSanAntonioHSTVisibilty:
         assert_sun_elevation_at_date(self.location, vis_end_pt.dt, -8.0)   # vis_end_pt.sun_elevation = -8.0
 
         # Find next pass
-        pass_ = self.observer.get_next_pass(start, visible_only=True)
+        pass_ = self.observer.next_pass(start, visible_only=True)
         tol = {
             'dt_tol': 1.5,
             'el_tol': 1,
@@ -291,7 +291,7 @@ class TestHeavensAboveCapeTownEnvisatVisibilty:
             vis_end = datetime.strptime(f"{date_str} {line_parts[8]}+0200", "%Y %d %b %H:%M:%S%z")
 
             # Find next pass
-            pass_ = self.observer.get_next_pass(date, limit_date=end, visible_only=True)
+            pass_ = self.observer.next_pass(date, limit_date=end, visible_only=True)
             assert_datetime_approx(pass_.vis_begin.dt, vis_begin, 1.5)
             assert_datetime_approx(pass_.vis_end.dt, vis_end, 1.5)
             assert_datetime_approx(pass_.vis_tca.dt, tca, 1.5)
@@ -341,7 +341,7 @@ class TestHeavensAboveCapeTownEnvisatVisibilty:
         assert_sun_elevation_at_date(self.location, los_pt.dt, -13.9)  # los_pt.sun_elevation = -13.9
 
         # Find next pass
-        pass_ = self.observer.get_next_pass(start, visible_only=True)
+        pass_ = self.observer.next_pass(start, visible_only=True)
         tol = {
             'dt_tol': 1.5,
             'el_tol': 1,
@@ -394,7 +394,7 @@ class TestHeavensAboveCapeTownEnvisatVisibilty:
         assert_sun_elevation_at_date(self.location, los_pt.dt, -4.2)  # los_pt.sun_elevation = -4.2
 
         # Find next pass
-        pass_ = self.observer.get_next_pass(start, visible_only=True)
+        pass_ = self.observer.next_pass(start, visible_only=True)
         tol = {
             'dt_tol': 1.5,
             'el_tol': 1,


### PR DESCRIPTION
…es instead of an iterator.

Change Observer.get_next_pass() to .next_pass() and raise DeprecationWarning

Raise DeprecationWarning on Observer.predictor